### PR TITLE
Fix sign-in logic

### DIFF
--- a/article4/api/src/controllers/auth.ts
+++ b/article4/api/src/controllers/auth.ts
@@ -20,7 +20,8 @@ export const signIn = async (req: Request, res: Response, next: NextFunction) =>
     }
 
     const user = await User.findOne({ email: email.toLowerCase() });
-    if (user && (await user.comparePassword(password))) {
+
+    if (!user || !(await user.comparePassword(password))) {
       res.status(401).json({ message: 'Invalid email or password' });
       return;
     }


### PR DESCRIPTION
## Summary
- correct credential validation in sign-in controller

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fd5add4a083298b04b94a23155a75