### PR TITLE
Add Jest test setup and sample API tests

### DIFF
--- a/article4/api/jest.config.js
+++ b/article4/api/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+};

--- a/article4/api/package.json
+++ b/article4/api/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon src/index.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -29,6 +29,10 @@
     "bcrypt": "^6.0.0",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/article4/api/src/__mocks__/express.ts
+++ b/article4/api/src/__mocks__/express.ts
@@ -1,0 +1,11 @@
+const express = jest.fn(() => ({
+  use: jest.fn(),
+  listen: jest.fn((port, cb) => cb && cb()),
+}));
+express.Router = jest.fn(() => ({
+  use: jest.fn(),
+  post: jest.fn(),
+  get: jest.fn(),
+  delete: jest.fn(),
+}));
+export default express;

--- a/article4/api/src/__mocks__/models.ts
+++ b/article4/api/src/__mocks__/models.ts
@@ -1,0 +1,14 @@
+export const Tenant = {
+  findOne: jest.fn(),
+};
+
+export const Book = {
+  create: jest.fn(),
+  find: jest.fn(),
+  findByIdAndDelete: jest.fn(),
+};
+
+export const User = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+};

--- a/article4/api/src/__mocks__/services.ts
+++ b/article4/api/src/__mocks__/services.ts
@@ -1,0 +1,16 @@
+export const MongoService = {
+  connect: jest.fn(),
+  getTenantConnection: jest.fn(),
+};
+
+export const RedisService = {
+  connect: jest.fn(),
+  getClient: jest.fn(),
+};
+
+export const TenantService = {
+  getTenantIdBySubdomain: jest.fn(),
+  isTenantInitialized: jest.fn(),
+  setTenantInitialized: jest.fn(),
+  createTenant: jest.fn(),
+};

--- a/article4/api/tests/controllers/auth.test.ts
+++ b/article4/api/tests/controllers/auth.test.ts
@@ -1,0 +1,58 @@
+import { signUp } from '../../src/controllers/auth';
+import { MongoService } from '../../src/services';
+import { Request, Response, NextFunction } from 'express';
+import { toRequestUser } from '../../src/lib';
+
+jest.mock('../../src/services');
+jest.mock('../../src/lib');
+
+const mockRequest = (body: any = {}): Partial<Request> => ({ body, tenantId: 'tid' });
+
+const mockResponse = () => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+const mockNext = () => jest.fn();
+
+describe('signUp', () => {
+  it('returns 400 when fields missing', async () => {
+    const req = mockRequest({ email: '', password: '' });
+    const res = mockResponse();
+    const next = mockNext();
+
+    await signUp(req as Request, res, next as NextFunction);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('creates user and returns 201', async () => {
+    const req = mockRequest({ email: 'a@b.com', password: '123' });
+    const res = mockResponse();
+    const next = mockNext();
+
+    const mockUser = { save: jest.fn(), _id: { toHexString: () => 'id' }, email: 'a@b.com', createdAt: new Date(), updatedAt: new Date() };
+    const model = jest.fn().mockReturnValue({ findOne: jest.fn().mockResolvedValue(null), create: jest.fn(), });
+    model.mockReturnValueOnce({ findOne: jest.fn().mockResolvedValue(null) });
+    (MongoService.getTenantConnection as jest.Mock).mockReturnValue({ model: () => ({ findOne: jest.fn().mockResolvedValue(null) }) });
+
+    (MongoService.getTenantConnection as jest.Mock).mockReturnValue({ model: () => ({ findOne: jest.fn().mockResolvedValue(null) }) });
+
+    // Instead of actual save, we simulate creation
+    (MongoService.getTenantConnection as jest.Mock).mockReturnValue({
+      model: () => ({
+        findOne: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue(mockUser),
+      }),
+    });
+
+    (toRequestUser as jest.Mock).mockReturnValue({ id: 'id', email: 'a@b.com' });
+
+    await signUp(req as Request, res, next as NextFunction);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalled();
+  });
+});

--- a/article4/api/tests/index.test.ts
+++ b/article4/api/tests/index.test.ts
@@ -1,0 +1,17 @@
+import { MongoService, RedisService } from '../src/services';
+
+jest.mock('express');
+
+jest.mock('../src/services');
+
+describe('app initialization', () => {
+  it('calls connect on services', async () => {
+    (MongoService.connect as jest.Mock).mockResolvedValue();
+    (RedisService.connect as jest.Mock).mockResolvedValue();
+
+    await import('../src/index');
+
+    expect(MongoService.connect).toHaveBeenCalled();
+    expect(RedisService.connect).toHaveBeenCalled();
+  });
+});

--- a/article4/api/tests/middleware/error.test.ts
+++ b/article4/api/tests/middleware/error.test.ts
@@ -1,0 +1,38 @@
+import { errorHandler } from '../../src/middleware/error';
+import { Request, Response, NextFunction } from 'express';
+
+const mockRequest = (): Partial<Request> => ({ headers: {} });
+
+const mockResponse = (headersSent = false) => {
+  const res: Partial<Response> = { headersSent };
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+const mockNext = () => jest.fn();
+
+describe('errorHandler', () => {
+  it('should forward error if headers already sent', () => {
+    const req = mockRequest();
+    const res = mockResponse(true);
+    const next = mockNext();
+    const error = new Error('boom');
+
+    errorHandler(error, req as Request, res as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith(error);
+  });
+
+  it('should respond with json error', () => {
+    const req = mockRequest();
+    const res = mockResponse(false);
+    const next = mockNext();
+    const error = new Error('fail');
+
+    errorHandler(error, req as Request, res as Response, next as NextFunction);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ message: 'fail' }));
+  });
+});

--- a/article4/api/tests/middleware/tenant.test.ts
+++ b/article4/api/tests/middleware/tenant.test.ts
@@ -1,0 +1,73 @@
+import { extractTenant, setupTenant } from '../../src/middleware/tenant';
+import { TenantService, MongoService } from '../../src/services';
+import { Request, Response, NextFunction } from 'express';
+
+jest.mock('../../src/services');
+
+const mockRequest = (headers: any = {}, body: any = {}): Partial<Request> => ({
+  headers,
+  body,
+});
+
+const mockResponse = () => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+const mockNext = () => jest.fn();
+
+describe('extractTenant', () => {
+  it('should throw error if host header is missing', async () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const next = mockNext();
+
+    await extractTenant(req as Request, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('should set tenantId from service', async () => {
+    (TenantService.getTenantIdBySubdomain as jest.Mock).mockResolvedValue('tid');
+    const req = mockRequest({ host: 'foo.example.com' });
+    const res = mockResponse();
+    const next = mockNext();
+
+    await extractTenant(req as Request, res, next as NextFunction);
+
+    expect(req.tenantId).toBe('tid');
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+describe('setupTenant', () => {
+  it('should throw error if tenantId missing', async () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const next = mockNext();
+
+    await setupTenant(req as Request, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('should initialize models if not initialized', async () => {
+    const req = mockRequest();
+    req.tenantId = 'tid';
+    const res = mockResponse();
+    const next = mockNext();
+
+    const mockDb = { models: {}, model: jest.fn() };
+    (TenantService.isTenantInitialized as jest.Mock).mockResolvedValue(false);
+    (MongoService.getTenantConnection as jest.Mock).mockReturnValue(mockDb);
+
+    await setupTenant(req as Request, res, next as NextFunction);
+
+    expect(mockDb.model).toHaveBeenCalled();
+    expect(TenantService.setTenantInitialized).toHaveBeenCalledWith('tid');
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/article4/api/tests/services/tenant.test.ts
+++ b/article4/api/tests/services/tenant.test.ts
@@ -1,0 +1,37 @@
+import TenantService from '../../src/services/tenant';
+import { RedisService } from '../../src/services';
+import { Tenant } from '../../src/models';
+
+jest.mock('../../src/services/redis');
+jest.mock('../../src/models');
+
+describe('TenantService.getTenantIdBySubdomain', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns id from cache', async () => {
+    (RedisService.getClient as jest.Mock).mockReturnValue({ get: jest.fn().mockResolvedValue('cached') });
+    const id = await TenantService.getTenantIdBySubdomain('foo');
+    expect(id).toBe('cached');
+  });
+
+  it('queries db when cache misses', async () => {
+    (RedisService.getClient as jest.Mock).mockReturnValue({
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+    });
+    (Tenant.findOne as jest.Mock).mockResolvedValue({ _id: { toHexString: () => 'dbid' } });
+    const id = await TenantService.getTenantIdBySubdomain('bar');
+    expect(id).toBe('dbid');
+  });
+});
+
+describe('TenantService.setTenantInitialized', () => {
+  it('sets flag in redis', async () => {
+    const set = jest.fn();
+    (RedisService.getClient as jest.Mock).mockReturnValue({ set });
+    await TenantService.setTenantInitialized('tid');
+    expect(set).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with ts-jest for the article4 API
- add manual mocks for express, services and models
- create initial unit tests for middleware, services, controller and app startup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe2b677988329b33e7738313b8d5e